### PR TITLE
CLI/LIB: Add '-p', '--purpose'

### DIFF
--- a/cmd/gompw/flags.go
+++ b/cmd/gompw/flags.go
@@ -40,7 +40,6 @@ func handleFlags(mpw *MPW) {
 	var flagListPasswordTypes bool
 	var flagShowVersion bool
 	var ignoreConfigFile bool
-	var passwordPurpose string
 	var pwBytes []byte
 	var pwInput io.Reader
 
@@ -58,6 +57,7 @@ func handleFlags(mpw *MPW) {
 		//             MP_DEBUG
 		//             MP_DUMP
 		fmt.Println("  MP_FULLNAME     | The full name of the user (see -u)")
+		fmt.Println("  MP_PWPURPOSE    | The password purpose (see -p)")
 		fmt.Println("  MP_PWTYPE       | The password type (see -t)")
 		fmt.Println("  MP_SEED         | The master password seed (see -S)")
 		fmt.Println("  MP_SITE         | The site for generated password")
@@ -98,7 +98,7 @@ func handleFlags(mpw *MPW) {
 	flag.StringVarP(&configFile, "config", "C", "", "User configuration file override")
 	flag.StringVarP(&mpw.Config.Fullname, "fullname", "u", os.Getenv("MP_FULLNAME"), "Fullname")
 	flag.StringVarP(&mpw.Config.MasterPasswordSeed, "mpseed", "S", flagDefaults(common.DefaultMasterPasswordSeed, os.Getenv("MP_SEED")), "Override the Master Password Seed")
-	flag.StringVarP(&passwordPurpose, "purpose", "p", "", flagHelp("p"))
+	flag.StringVarP(&mpw.Config.PasswordPurpose, "purpose", "p", flagDefaults(common.DefaultPasswordPurpose, os.Getenv("MP_PWPURPOSE")), flagHelp("p"))
 	flag.StringVarP(&mpw.Config.PasswordType, "pwtype", "t", flagDefaults(common.DefaultPasswordType, os.Getenv("MP_PWTYPE")), flagHelp("t"))
 	flag.StringVarP(&mpw.pwFile, "file", "f", "", "Read user's master password from given filename")
 	flag.Uint32VarP(&mpw.Config.Counter, "counter", "c", flagDefaultCounter(common.DefaultCounter, os.Getenv("MP_SITECOUNTER")), "Site password counter value")

--- a/cmd/gompw/flags.go
+++ b/cmd/gompw/flags.go
@@ -40,6 +40,7 @@ func handleFlags(mpw *MPW) {
 	var flagListPasswordTypes bool
 	var flagShowVersion bool
 	var ignoreConfigFile bool
+	var passwordPurpose string
 	var pwBytes []byte
 	var pwInput io.Reader
 
@@ -97,6 +98,7 @@ func handleFlags(mpw *MPW) {
 	flag.StringVarP(&configFile, "config", "C", "", "User configuration file override")
 	flag.StringVarP(&mpw.Config.Fullname, "fullname", "u", os.Getenv("MP_FULLNAME"), "Fullname")
 	flag.StringVarP(&mpw.Config.MasterPasswordSeed, "mpseed", "S", flagDefaults(common.DefaultMasterPasswordSeed, os.Getenv("MP_SEED")), "Override the Master Password Seed")
+	flag.StringVarP(&passwordPurpose, "purpose", "p", "", flagHelp("p"))
 	flag.StringVarP(&mpw.Config.PasswordType, "pwtype", "t", flagDefaults(common.DefaultPasswordType, os.Getenv("MP_PWTYPE")), flagHelp("t"))
 	flag.StringVarP(&mpw.pwFile, "file", "f", "", "Read user's master password from given filename")
 	flag.Uint32VarP(&mpw.Config.Counter, "counter", "c", flagDefaultCounter(common.DefaultCounter, os.Getenv("MP_SITECOUNTER")), "Site password counter value")

--- a/cmd/gompw/output.go
+++ b/cmd/gompw/output.go
@@ -28,15 +28,16 @@ import (
 
 const passwordTypeHelpIndent = 28
 
+// cannot disable the pflag automatic adding of: (default xxx)
 var helpMsg = map[string]string{
 	"p": `The purpose of the generated token
-Defaults to 'auth'
     a, auth     | An authentication token such as a password
     i, ident    | An identification token such as a username
-    r, rec      | A recovery token such as a security answer`,
+    r, rec      | A recovery token such as a security answer
+    NOTE: only 'auth' supports a counter > 1
+`,
 
 	"t": `Specify the password's type template
-Defaults to 'long'
     x, maximum  | 20 characters, contains symbols
     l, long     | Copy-friendly, 14 characters, symbols
     m, medium   | Copy-friendly, 8 characters, symbols
@@ -44,7 +45,8 @@ Defaults to 'long'
     s, short    | Copy-friendly, 4 characters, no symbols
     i, pin      | 4 numbers
     n, name     | 9 letter name
-    p, phrase   | 20 character sentence`,
+    p, phrase   | 20 character sentence
+`,
 }
 
 func flagHelp(opt string) string {

--- a/cmd/gompw/output.go
+++ b/cmd/gompw/output.go
@@ -28,7 +28,14 @@ import (
 
 const passwordTypeHelpIndent = 28
 
-var passwordTypeHelp = `Specify the password's type template
+var helpMsg = map[string]string {
+	"p": `The purpose of the generated token
+Defaults to 'auth'
+    a, auth     | An authentication token such as a password
+    i, ident    | An identification token such as a username
+    r, rec      | A recovery token such as a security answer`,
+
+	"t": `Specify the password's type template
 Defaults to 'long'
     x, maximum  | 20 characters, contains symbols
     l, long     | Copy-friendly, 14 characters, symbols
@@ -37,17 +44,17 @@ Defaults to 'long'
     s, short    | Copy-friendly, 4 characters, no symbols
     i, pin      | 4 numbers
     n, name     | 9 letter name
-    p, phrase   | 20 character sentence`
+    p, phrase   | 20 character sentence`,
+}
 
 func flagHelp(opt string) string {
-	var help string
-	switch opt {
-	case "t":
-		indention := strings.Repeat(" ", passwordTypeHelpIndent)
-		help = strings.Replace(passwordTypeHelp, "\n", "\n"+indention, -1)
+	if _, ok := helpMsg[opt]; !ok {
+		return ""
 	}
 
-	return help
+	indention := strings.Repeat(" ", passwordTypeHelpIndent)
+
+	return strings.Replace(helpMsg[opt], "\n", "\n"+indention, -1)
 }
 
 func printPassword(mpw *MPW, pw string) {

--- a/cmd/gompw/output.go
+++ b/cmd/gompw/output.go
@@ -28,7 +28,7 @@ import (
 
 const passwordTypeHelpIndent = 28
 
-var helpMsg = map[string]string {
+var helpMsg = map[string]string{
 	"p": `The purpose of the generated token
 Defaults to 'auth'
     a, auth     | An authentication token such as a password

--- a/pkg/common/defaults.go
+++ b/pkg/common/defaults.go
@@ -20,7 +20,7 @@
 
 package common
 
-// MasterPasswordSeed is the default seed and allows it to be compatible with
+// DefaultMasterPasswordSeed defaults to the universal seed as defined by:
 // http://masterpasswordapp.com/algorithm.html
 const (
 	// config
@@ -30,4 +30,5 @@ const (
 
 	// crypto
 	DefaultMasterPasswordSeed = "com.lyndir.masterpassword"
+	DefaultPasswordPurpose    = "auth"
 )

--- a/pkg/config/merge.go
+++ b/pkg/config/merge.go
@@ -37,6 +37,7 @@ var (
 			"PasswordType":       struct{}{},
 			"Fullname":           struct{}{},
 			"Password":           struct{}{},
+			"PasswordPurpose":    struct{}{},
 			"Site":               struct{}{},
 			"Counter":            struct{}{},
 		}
@@ -76,6 +77,9 @@ func (mpc *MPConfig) Merge(c *MPConfig) {
 	}
 	if mpc.Password == "" {
 		mpc.Password = c.Password
+	}
+	if mpc.PasswordPurpose == "" {
+		mpc.PasswordPurpose = c.PasswordPurpose
 	}
 	if mpc.Site == "" {
 		mpc.Site = c.Site

--- a/pkg/config/mpConfig.go
+++ b/pkg/config/mpConfig.go
@@ -34,6 +34,7 @@ const (
 // userConfig =unmarshal=> MPConfig =merge=> MasterPW
 type MPConfig struct {
 	MasterPasswordSeed string `toml:"masterPasswordSeed,omitempty"`
+	PasswordPurpose    string `toml:"passwordPurpose,omitempty"`
 	PasswordType       string `toml:"passwordType,omitempty"`
 	Fullname           string `toml:"fullname,omitempty"`
 	Password           string `toml:"password,omitempty"`

--- a/pkg/config/userConfigFile_internal_test.go
+++ b/pkg/config/userConfigFile_internal_test.go
@@ -71,7 +71,7 @@ func TestLoadConfig(t *testing.T) {
 
 	// test against empty gompw.toml
 	expected = &config.MPConfig{
-		MasterPasswordSeed: common.MasterPasswordSeed,
+		MasterPasswordSeed: common.DefaultMasterPasswordSeed,
 		PasswordType:       "long",
 		Counter:            1,
 	}

--- a/pkg/crypto/masterPassword.go
+++ b/pkg/crypto/masterPassword.go
@@ -43,7 +43,7 @@ const MpwSeries = "2.6"
 const DefaultMasterPasswordSeed = common.DefaultMasterPasswordSeed
 
 var (
-	Dbg = debug.NewDebug().Dbg
+	Dbg  = debug.NewDebug().Dbg
 	DbgO = debug.NewDebug().DbgO
 )
 
@@ -121,14 +121,14 @@ func (mpw *MasterPW) MasterPassword() (string, error) {
 	Dbg("siteCounter: %d", mpw.counter)
 	// FIXME: stringer doesn't appear to be working right
 	Dbg("keyPurpose: %d (%s)", mpw.passwordPurpose, mpw.passwordPurpose.String())
-	Dbg("keyContext: (null)")  // not implemented
+	Dbg("keyContext: (null)") // not implemented
 	Dbg("keyScope: %s", mpseed)
 	Dbg("siteSalt: keyScope=%s | #siteName=%08X | siteName=%s | siteCounter=%08d | #keyContext=(null) | keyContext=(null)",
 		mpseed, len(mpw.site), mpw.site, mpw.counter)
 
 	// Danger Will Robinson, passwordPurpose comes into effect here, so caution with the Truncate()
 	buffer.Truncate(len(mpw.masterPasswordSeed))
-	buffer.WriteString(mpw.purpose())  // add the passwordPurpose suffix
+	buffer.WriteString(mpw.purpose()) // add the passwordPurpose suffix
 	binary.Write(&buffer, binary.BigEndian, uint32(len(mpw.site)))
 	buffer.WriteString(mpw.site)
 	binary.Write(&buffer, binary.BigEndian, mpw.counter)

--- a/pkg/crypto/masterPassword.go
+++ b/pkg/crypto/masterPassword.go
@@ -45,6 +45,7 @@ const DefaultMasterPasswordSeed = common.DefaultMasterPasswordSeed
 type MasterPW struct {
 	Config             *config.MPConfig
 	masterPasswordSeed string
+	passwordPurpose    PasswordPurpose
 	passwordType       string
 	fullname           string
 	password           string
@@ -123,11 +124,12 @@ func (mpw *MasterPW) MasterPassword() (string, error) {
 // MasterPassword returns a derived password according to: http://masterpasswordapp.com/algorithm.html
 //
 //   Valid PasswordTypes: basic, long, maximum, medium, name, phrase, pin, short
-func MasterPassword(mpwseed, passwordType, fullname, password, site string, counter uint32) (string, error) {
+func MasterPassword(mpwseed, passwordType, passwordPurpose, fullname, password, site string, counter uint32) (string, error) {
 	mpw := &MasterPW{
 		Config:             &config.MPConfig{},
 		masterPasswordSeed: mpwseed,
 		passwordType:       passwordType,
+		passwordPurpose:    passwordPurpose,
 		fullname:           fullname,
 		password:           password,
 		site:               site,

--- a/pkg/crypto/masterPassword.go
+++ b/pkg/crypto/masterPassword.go
@@ -126,12 +126,13 @@ func MasterPassword(mpwseed, passwordType, passwordPurpose, fullname, password, 
 		Config:             &config.MPConfig{},
 		masterPasswordSeed: mpwseed,
 		passwordType:       passwordType,
-		passwordPurpose:    passwordPurpose,
 		fullname:           fullname,
 		password:           password,
 		site:               site,
 		counter:            counter,
 	}
+	// needs to be set via method for validation
+	mpw.SetPasswordPurpose(passwordPurpose)
 
 	return mpw.MasterPassword()
 }

--- a/pkg/crypto/masterPassword_test.go
+++ b/pkg/crypto/masterPassword_test.go
@@ -40,6 +40,7 @@ type testVector struct {
 	ms     string
 	c      uint32
 	pt     string
+	pp     string
 	expect string
 }
 
@@ -56,6 +57,7 @@ func newMpw(tv testVector) (*crypto.MasterPW, error) {
 		MasterPasswordSeed: tv.ms,
 		Counter:            tv.c,
 		PasswordType:       tv.pt,
+		PasswordPurpose:    tv.pp,
 		Fullname:           d.u,
 		Password:           d.pw,
 		Site:               d.s,
@@ -69,29 +71,29 @@ func newMpw(tv testVector) (*crypto.MasterPW, error) {
 }
 func TestMasterPassword(t *testing.T) {
 	expectations := []testVector{
-		{mpwseeds[0], 1, "long", "ZedaFaxcZaso9*"},
-		{mpwseeds[0], 2, "long", "Fovi2@JifpTupx"},
-		{mpwseeds[0], 1, "maximum", "pf4zS1LjCg&LjhsZ7T2~"},
-		{mpwseeds[0], 1, "medium", "ZedJuz8$"},
-		{mpwseeds[0], 1, "basic", "pIS54PLs"},
-		{mpwseeds[0], 1, "short", "Zed5"},
-		{mpwseeds[0], 1, "pin", "6685"},
-		{mpwseeds[0], 1, "name", "zedjuzoco"},
-		{mpwseeds[0], 1, "phrase", "ze juzxo sax taxocre"},
+		{mpwseeds[0], 1, "long", "auth", "ZedaFaxcZaso9*"},
+		{mpwseeds[0], 2, "long", "auth", "Fovi2@JifpTupx"},
+		{mpwseeds[0], 1, "maximum", "auth", "pf4zS1LjCg&LjhsZ7T2~"},
+		{mpwseeds[0], 1, "medium", "auth", "ZedJuz8$"},
+		{mpwseeds[0], 1, "basic", "auth", "pIS54PLs"},
+		{mpwseeds[0], 1, "short", "auth", "Zed5"},
+		{mpwseeds[0], 1, "pin", "auth", "6685"},
+		{mpwseeds[0], 1, "name", "auth", "zedjuzoco"},
+		{mpwseeds[0], 1, "phrase", "auth", "ze juzxo sax taxocre"},
 	}
 
 	expectations_bad := []testVector{
-		{mpwseeds[0], 1, "invalidType", "1111"},
+		{mpwseeds[0], 1, "invalidType", "auth", "1111"},
 	}
 
 	for _, tv := range expectations {
-		pw, err := crypto.MasterPassword(tv.ms, tv.pt, d.u, d.pw, d.s, tv.c)
+		pw, err := crypto.MasterPassword(tv.ms, tv.pt, tv.pp, d.u, d.pw, d.s, tv.c)
 		assert.NoError(t, err)
 		assert.Equal(t, tv.expect, pw)
 	}
 
 	for _, tv := range expectations_bad {
-		_, err := crypto.MasterPassword(tv.ms, tv.pt, d.u, d.pw, d.s, tv.c)
+		_, err := crypto.MasterPassword(tv.ms, tv.pt, tv.pp, d.u, d.pw, d.s, tv.c)
 		assert.Error(t, err)
 	}
 
@@ -108,37 +110,37 @@ func TestMasterPassword(t *testing.T) {
 func TestMasterPasswordSeeds(t *testing.T) {
 	expectations := [][]testVector{
 		{
-			{mpwseeds[1], 1, "long", "NukiConqYocu1*"},
-			{mpwseeds[1], 2, "long", "MiwkVuruDile0_"},
-			{mpwseeds[1], 1, "maximum", "CR(m#EbdFijOx8u!bX1$"},
-			{mpwseeds[1], 1, "medium", "NukKun1:"},
-			{mpwseeds[1], 1, "basic", "CbL24Pbd"},
-			{mpwseeds[1], 1, "short", "Nuk2"},
-			{mpwseeds[1], 1, "pin", "5902"},
-			{mpwseeds[1], 1, "name", "nukkunequ"},
-			{mpwseeds[1], 1, "phrase", "nu kunno rom tolivna"},
+			{mpwseeds[1], 1, "long", "auth", "NukiConqYocu1*"},
+			{mpwseeds[1], 2, "long", "auth", "MiwkVuruDile0_"},
+			{mpwseeds[1], 1, "maximum", "auth", "CR(m#EbdFijOx8u!bX1$"},
+			{mpwseeds[1], 1, "medium", "auth", "NukKun1:"},
+			{mpwseeds[1], 1, "basic", "auth", "CbL24Pbd"},
+			{mpwseeds[1], 1, "short", "auth", "Nuk2"},
+			{mpwseeds[1], 1, "pin", "auth", "5902"},
+			{mpwseeds[1], 1, "name", "auth", "nukkunequ"},
+			{mpwseeds[1], 1, "phrase", "auth", "nu kunno rom tolivna"},
 		},
 		{
-			{mpwseeds[2], 1, "long", "GibuKaqoNeld5/"},
-			{mpwseeds[2], 2, "long", "QuncPute3/Wuzk"},
-			{mpwseeds[2], 1, "maximum", "a7?OMCHdbHoa1Q4&mc2)"},
-			{mpwseeds[2], 1, "medium", "Gib9;Luq"},
-			{mpwseeds[2], 1, "basic", "aiq91zOd"},
-			{mpwseeds[2], 1, "short", "Gib9"},
-			{mpwseeds[2], 1, "pin", "9779"},
-			{mpwseeds[2], 1, "name", "gibmeluqe"},
-			{mpwseeds[2], 1, "phrase", "gi melqo bod kahuwqa"},
+			{mpwseeds[2], 1, "long", "auth", "GibuKaqoNeld5/"},
+			{mpwseeds[2], 2, "long", "auth", "QuncPute3/Wuzk"},
+			{mpwseeds[2], 1, "maximum", "auth", "a7?OMCHdbHoa1Q4&mc2)"},
+			{mpwseeds[2], 1, "medium", "auth", "Gib9;Luq"},
+			{mpwseeds[2], 1, "basic", "auth", "aiq91zOd"},
+			{mpwseeds[2], 1, "short", "auth", "Gib9"},
+			{mpwseeds[2], 1, "pin", "auth", "9779"},
+			{mpwseeds[2], 1, "name", "auth", "gibmeluqe"},
+			{mpwseeds[2], 1, "phrase", "auth", "gi melqo bod kahuwqa"},
 		},
 		{
-			{mpwseeds[3], 1, "long", "Mobl2-BicuKasp"},
-			{mpwseeds[3], 2, "long", "JeyzXawx5~Heye"},
-			{mpwseeds[3], 1, "maximum", "z3)1NfH6^3B(octEFYFU"},
-			{mpwseeds[3], 1, "medium", "Mob7(Rer"},
-			{mpwseeds[3], 1, "basic", "zuP7mfR2"},
-			{mpwseeds[3], 1, "short", "Mob7"},
-			{mpwseeds[3], 1, "pin", "1317"},
-			{mpwseeds[3], 1, "name", "moblirere"},
-			{mpwseeds[3], 1, "phrase", "mobl rer nuksiri wuc"},
+			{mpwseeds[3], 1, "long", "auth", "Mobl2-BicuKasp"},
+			{mpwseeds[3], 2, "long", "auth", "JeyzXawx5~Heye"},
+			{mpwseeds[3], 1, "maximum", "auth", "z3)1NfH6^3B(octEFYFU"},
+			{mpwseeds[3], 1, "medium", "auth", "Mob7(Rer"},
+			{mpwseeds[3], 1, "basic", "auth", "zuP7mfR2"},
+			{mpwseeds[3], 1, "short", "auth", "Mob7"},
+			{mpwseeds[3], 1, "pin", "auth", "1317"},
+			{mpwseeds[3], 1, "name", "auth", "moblirere"},
+			{mpwseeds[3], 1, "phrase", "auth", "mobl rer nuksiri wuc"},
 		},
 	}
 

--- a/pkg/crypto/masterPassword_test.go
+++ b/pkg/crypto/masterPassword_test.go
@@ -202,7 +202,6 @@ func TestMasterPasswordPurposeGood(t *testing.T) {
 			{mpwseeds[2], 1, "name", "rec", "viwjipubu"},
 			{mpwseeds[2], 1, "phrase", "rec", "viwj pub daysixu jad"},
 		},
-
 	}
 
 	for _, tvs := range expectations {
@@ -221,25 +220,29 @@ func TestMasterPasswordPurposeGood(t *testing.T) {
 }
 
 func TestMasterPasswordPurposeBad(t *testing.T) {
-	expectations := []struct{
-		tv testVector
+	expectations := []struct {
+		tv        testVector
 		sppE, mpE error
 	}{
-			{testVector{mpwseeds[0], 1, "long", "noexist", "noneshallpass!"}, crypto.ErrPasswordPurposeInvalid, crypto.ErrPasswordPurposeInvalid},
-			{testVector{mpwseeds[0], 69, "long", "noexist", "'tisbutascratch!"}, crypto.ErrPasswordPurposeInvalid, crypto.ErrPasswordPurposeInvalid},
-			{testVector{mpwseeds[0], 69, "long", "ident", "ascratch?yourarmsoff"}, crypto.ErrPasswordPurposeInvalid, crypto.ErrPasswordPurposeCounterOutOfRange},
-			{testVector{mpwseeds[0], 69, "long", "rec", "it'sjustafleshwound"}, crypto.ErrPasswordPurposeInvalid, crypto.ErrPasswordPurposeCounterOutOfRange},
+		{testVector{mpwseeds[0], 1, "long", "noexist", "noneshallpass!"}, crypto.ErrPasswordPurposeInvalid, crypto.ErrPasswordPurposeInvalid},
+		{testVector{mpwseeds[0], 69, "long", "noexist", "'tisbutascratch!"}, crypto.ErrPasswordPurposeInvalid, crypto.ErrPasswordPurposeInvalid},
+		{testVector{mpwseeds[0], 69, "long", "ident", "ascratch?yourarmsoff"}, crypto.ErrPasswordPurposeInvalid, crypto.ErrPasswordPurposeCounterOutOfRange},
+		{testVector{mpwseeds[0], 69, "long", "rec", "it'sjustafleshwound"}, crypto.ErrPasswordPurposeInvalid, crypto.ErrPasswordPurposeCounterOutOfRange},
 	}
 
 	for _, e := range expectations {
-			mpw := &crypto.MasterPW{Config: newMpConfig(e.tv)}
+		mpw := &crypto.MasterPW{Config: newMpConfig(e.tv)}
 
-			// test SetPasswordPurpose() validation path
-			err := mpw.SetPasswordPurpose(e.tv.ms)
-			if assert.Error(t, err) { assert.Equal(t, err, e.sppE) }
+		// test SetPasswordPurpose() validation path
+		err := mpw.SetPasswordPurpose(e.tv.ms)
+		if assert.Error(t, err) {
+			assert.Equal(t, err, e.sppE)
+		}
 
-			// test MasterPassword() validation path via MergeConfig()
-			_, err = mpw.MasterPassword()
-			if assert.Error(t, err) { assert.Equal(t, err, e.mpE) }
+		// test MasterPassword() validation path via MergeConfig()
+		_, err = mpw.MasterPassword()
+		if assert.Error(t, err) {
+			assert.Equal(t, err, e.mpE)
+		}
 	}
 }

--- a/pkg/crypto/merge.go
+++ b/pkg/crypto/merge.go
@@ -34,6 +34,9 @@ func (mpw *MasterPW) MergeConfigEX(c *config.MPConfig) error {
 	if mpw.masterPasswordSeed == "" {
 		mpw.masterPasswordSeed = c.MasterPasswordSeed
 	}
+	if mpw.passwordPurpose == PasswordPurposeUnSet {
+		mpw.SetPasswordPurpose(c.PasswordPurpose)
+	}
 	if mpw.passwordType == "" {
 		mpw.passwordType = c.PasswordType
 	}

--- a/pkg/crypto/passwordPurpose.go
+++ b/pkg/crypto/passwordPurpose.go
@@ -36,8 +36,9 @@ const (
 )
 
 var (
-	ErrPasswordPurposeEmpty   = errors.New("Site password purpose must be set")
-	ErrPasswordPurposeInvalid = errors.New("Invalid site password purpose")
+	ErrPasswordPurposeEmpty             = errors.New("Site password purpose must be set")
+	ErrPasswordPurposeInvalid           = errors.New("Invalid site password purpose")
+	ErrPasswordPurposeCounterOutOfRange = errors.New("Site password purpose is using an out of range counter")
 )
 
 var (
@@ -63,9 +64,11 @@ var (
 // in a consistent manner.
 //
 //   0) *Unset*
-//   1) Authentication
-//   2) Identification
-//   3) Recovery
+//   1) Authentication  (counter=N)
+//   2) Identification  (counter=1)
+//   3) Recovery        (counter=1)
+//
+//   NOTE: Authentication is perturbed by counter, whereas the others are not.
 type PasswordPurpose int
 
 func (p *PasswordPurpose) String() string {
@@ -101,6 +104,16 @@ func (pp *PasswordPurpose) Validate() error {
 	}
 
 	return nil
+}
+
+// PasswordPurposeToToken returns the const token associated with given purpose
+func PasswordPurposeToToken(purpose string) (PasswordPurpose, error) {
+	token, ok := ppmap[purpose]
+	if !ok {
+		return PasswordPurposeUnSet, ErrPasswordPurposeInvalid
+	}
+
+	return token, nil
 }
 
 // ValidatePasswordPurpose will test if given purpose is valid

--- a/pkg/crypto/passwordPurpose.go
+++ b/pkg/crypto/passwordPurpose.go
@@ -26,9 +26,9 @@ import (
 	"github.com/TerraTech/go-MasterPassword/pkg/common"
 )
 
-const (
-	DefaultPasswordPurpose = common.DefaultPasswordPurpose
+const DefaultPasswordPurpose = common.DefaultPasswordPurpose
 
+const (
 	PasswordPurposeUnSet PasswordPurpose = iota
 	PasswordPurposeAuthentication
 	PasswordPurposeIdentification

--- a/pkg/crypto/passwordPurpose.go
+++ b/pkg/crypto/passwordPurpose.go
@@ -1,0 +1,125 @@
+//==============================================================================
+// This file is part of go-MasterPassword
+// Copyright (c) 2017, TerraTech
+// Development funded by FutureQuest, Inc.
+//   https://www.FutureQuest.net
+//
+// go-MasterPassword is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// go-MasterPassword is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You can find a copy of the GNU General Public License in the
+// LICENSE file.  Alternatively, see <http://www.gnu.org/licenses/>.
+//==============================================================================
+
+package crypto
+
+import (
+	"errors"
+)
+
+const (
+	PasswordPurposeUnSet PasswordPurpose = iota
+	PasswordPurposeAuthentication
+	PasswordPurposeIdentification
+	PasswordPurposeRecovery
+)
+
+var (
+	ErrPasswordPurposeEmpty   = errors.New("Site password purpose must be set")
+	ErrPasswordPurposeInvalid = errors.New("Invalid site password purpose")
+)
+
+var (
+	ppmap = map[string]PasswordPurpose{
+		"a":     PasswordPurposeAuthentication,
+		"auth":  PasswordPurposeAuthentication,
+		"i":     PasswordPurposeIdentification,
+		"ident": PasswordPurposeIdentification,
+		"r":     PasswordPurposeRecovery,
+		"rec":   PasswordPurposeRecovery,
+	}
+
+	pampp = map[PasswordPurpose]string{
+		PasswordPurposeAuthentication: "auth",
+		PasswordPurposeIdentification: "ident",
+		PasswordPurposeRecovery:       "rec",
+	}
+)
+
+// PasswordPurpose allows for different generated passwords for same Site depending on its intended purpose.
+//
+// Given the same {fullname, password, site}, specifying a different 'purpose' will perturb the final generated password
+// in a consistent manner.
+//
+//   0) Authentication
+//   1) Identification
+//   2) Recovery
+type PasswordPurpose int
+
+func (p *PasswordPurpose) String() string {
+	switch *p {
+	case PasswordPurposeAuthentication:
+		return "Authentication"
+	case PasswordPurposeIdentification:
+		return "Identification"
+	case PasswordPurposeRecovery:
+		return "Recovery"
+	}
+
+	return ""
+}
+
+// SetPurpose sets the MasterPassword's generated password purpose
+func (mpw *MasterPW) SetPasswordPurpose(purpose string) (err error) {
+	if err = ValidatePasswordPurpose(purpose); err == nil {
+		mpw.passwordPurpose = ppmap[purpose]
+	}
+	return
+}
+
+// ValidatePasswordPurpose will test if MasterPW password purpose is valid
+func (mpw *MasterPW) ValidatePasswordPurpose() error {
+	return mpw.passwordPurpose.Validate()
+}
+
+// Validate will test if password purpose is valid
+func (pp *PasswordPurpose) Validate() error {
+	if _, ok := pampp[*pp]; !ok {
+		return ErrPasswordPurposeInvalid
+	}
+
+	return nil
+}
+
+// ValidatePasswordPurpose will test if given purpose is valid
+func ValidatePasswordPurpose(purpose string) error {
+	if purpose == "" {
+		return ErrPasswordPurposeEmpty
+	}
+	if _, ok := ppmap[purpose]; !ok {
+		return ErrPasswordPurposeInvalid
+	}
+
+	return nil
+}
+
+// purpose returns the string used to munge MasterPassword's seed
+func (mpw *MasterPW) purpose() string {
+	switch mpw.passwordPurpose {
+	case PasswordPurposeAuthentication:
+		return ""
+	case PasswordPurposeIdentification:
+		return ".login"
+	case PasswordPurposeRecovery:
+		return ".answer"
+	}
+
+	panic(ErrPasswordPurposeInvalid.Error())
+}

--- a/pkg/crypto/passwordPurpose.go
+++ b/pkg/crypto/passwordPurpose.go
@@ -22,9 +22,13 @@ package crypto
 
 import (
 	"errors"
+
+	"github.com/TerraTech/go-MasterPassword/pkg/common"
 )
 
 const (
+	DefaultPasswordPurpose = common.DefaultPasswordPurpose
+
 	PasswordPurposeUnSet PasswordPurpose = iota
 	PasswordPurposeAuthentication
 	PasswordPurposeIdentification

--- a/pkg/crypto/passwordPurpose.go
+++ b/pkg/crypto/passwordPurpose.go
@@ -62,9 +62,10 @@ var (
 // Given the same {fullname, password, site}, specifying a different 'purpose' will perturb the final generated password
 // in a consistent manner.
 //
-//   0) Authentication
-//   1) Identification
-//   2) Recovery
+//   0) *Unset*
+//   1) Authentication
+//   2) Identification
+//   3) Recovery
 type PasswordPurpose int
 
 func (p *PasswordPurpose) String() string {

--- a/pkg/crypto/setters.go
+++ b/pkg/crypto/setters.go
@@ -52,6 +52,10 @@ func (mpw *MasterPW) SetPassword(password string) (err error) {
 	return
 }
 
+/*
+ * SetPasswordPurpose(): passwordPurpose.go
+ */
+
 // SetPasswordType is a setter for MasterPW.passwordType
 func (mpw *MasterPW) SetPasswordType(pwtype string) (err error) {
 	if err = ValidatePasswordType(pwtype); err == nil {

--- a/pkg/crypto/utils.go
+++ b/pkg/crypto/utils.go
@@ -1,0 +1,33 @@
+//==============================================================================
+// This file is part of go-MasterPassword
+// Copyright (c) 2017, TerraTech
+// Development funded by FutureQuest, Inc.
+//   https://www.FutureQuest.net
+//
+// go-MasterPassword is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// go-MasterPassword is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You can find a copy of the GNU General Public License in the
+// LICENSE file.  Alternatively, see <http://www.gnu.org/licenses/>.
+//==============================================================================
+
+package crypto
+
+import (
+	"crypto/sha256"
+	"fmt"
+)
+
+// mpw_id_buf()
+func mpwIdBuf(buf []byte) string {
+	sum := sha256.Sum256(buf)
+
+	return fmt.Sprintf("%02X", sum)
+}

--- a/pkg/crypto/validate.go
+++ b/pkg/crypto/validate.go
@@ -101,6 +101,10 @@ func ValidatePassword(password string) error {
 	return nil
 }
 
+/*
+ * ValidatePasswordPurpose(): passwordPurpose.go
+ */
+
 // ValidatePasswordType verifies that passwordType is not empty and a valid type
 func ValidatePasswordType(passwordType string) error {
 	if passwordType == "" {

--- a/pkg/crypto/validate.go
+++ b/pkg/crypto/validate.go
@@ -66,6 +66,16 @@ func (mpw *MasterPW) Validate() error {
 		return err
 	}
 
+	// Extra test to catch the following constraints:
+	//   0 > auth >= 1
+	//   0 > ident <= 1
+	//   0 > rec   <= 1
+	if mpw.passwordPurpose != PasswordPurposeAuthentication {
+		if mpw.counter > 1 {
+			return ErrPasswordPurposeCounterOutOfRange
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/crypto/validate.go
+++ b/pkg/crypto/validate.go
@@ -38,15 +38,19 @@ var (
 //
 //   1) masterPasswordSeed
 //   2) passwordType
-//   3) fullname
-//   4) password
-//   5) site
-//   6) counter
+//   3) passwordPurpose
+//   4) fullname
+//   5) password
+//   6) site
+//   7) counter
 func (mpw *MasterPW) Validate() error {
 	if err := ValidateMasterPasswordSeed(mpw.masterPasswordSeed); err != nil {
 		return err
 	}
 	if err := ValidatePasswordType(mpw.passwordType); err != nil {
+		return err
+	}
+	if err := mpw.ValidatePasswordPurpose(); err != nil {
 		return err
 	}
 	if err := ValidateFullname(mpw.fullname); err != nil {

--- a/pkg/debug/debug.go
+++ b/pkg/debug/debug.go
@@ -76,7 +76,11 @@ func (d *Debug) Dbg(format string, a ...interface{}) {
 		return
 	}
 
-	log.Printf("[DEBUG] "+format, a...)
+	logIt(format, a...)
+}
+
+func (d *Debug) DbgO(format string, a ...interface{}) {
+	logIt(format, a...)
 }
 
 func (d *Debug) SetFilename(f string) {
@@ -98,6 +102,10 @@ func (d *Debug) wantDebug(cf string) bool {
 	}
 
 	return false
+}
+
+func logIt(format string, a ...interface{}) {
+	log.Printf("[DEBUG] "+format, a...)
 }
 
 func normalize(f string) string {

--- a/pkg/debug/debug.go
+++ b/pkg/debug/debug.go
@@ -1,0 +1,111 @@
+//==============================================================================
+// This file is part of go-MasterPassword
+// Copyright (c) 2017, TerraTech
+// Development funded by FutureQuest, Inc.
+//   https://www.FutureQuest.net
+//
+// go-MasterPassword is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// go-MasterPassword is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You can find a copy of the GNU General Public License in the
+// LICENSE file.  Alternatively, see <http://www.gnu.org/licenses/>.
+//==============================================================================
+
+package debug
+
+import (
+	"log"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"futurequest.net/FQgolibs/FQdebug"
+)
+
+var globalDebug *Debug
+
+var (
+	D        = FQdebug.D
+	MP_DEBUG string
+)
+
+type Debug struct {
+	enabled bool
+	files   []string
+}
+
+func init() {
+	globalDebug = NewDebug()
+	mpDebug := os.Getenv("MP_DEBUG")
+	if mpDebug != "" {
+		globalDebug.files = strings.Split(mpDebug, ",")
+		globalDebug.enabled = len(globalDebug.files) > 0
+	}
+}
+
+func NewDebug() *Debug {
+	if globalDebug != nil {
+		return globalDebug
+	}
+	globalDebug = &Debug{
+		files: make([]string, 0, 1),
+	}
+
+	return globalDebug
+}
+
+func (d *Debug) Dbg(format string, a ...interface{}) {
+	if !d.enabled {
+		return
+	}
+
+	_, f, _, ok := runtime.Caller(1)
+	if !ok {
+		return
+	}
+
+	if !d.wantDebug(f) {
+		return
+	}
+
+	log.Printf("[DEBUG] "+format, a...)
+}
+
+func (d *Debug) SetFilename(f string) {
+	// Stores the filename normalized
+	d.files = append(d.files, normalize(f))
+	d.enabled = true
+}
+
+// wantDebug will do a suffix based match for given filepath
+//
+//  e.g. /^.*${fp}$/
+func (d *Debug) wantDebug(cf string) bool {
+	//cf == caller filename
+	cf = normalize(cf)
+	for _, fn := range d.files {
+		if fn == "all" || strings.HasSuffix(cf, fn) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func normalize(f string) string {
+	// 1) make sure it has a leading slash
+	// 2) cleaned up
+	// 3) normalized for forward slash (Unix style)
+	f = filepath.Clean("/" + f)
+	f = filepath.ToSlash(f)
+
+	return f
+}

--- a/pkg/debug/debug_internal_test.go
+++ b/pkg/debug/debug_internal_test.go
@@ -1,0 +1,60 @@
+//==============================================================================
+// This file is part of go-MasterPassword
+// Copyright (c) 2017, TerraTech
+// Development funded by FutureQuest, Inc.
+//   https://www.FutureQuest.net
+//
+// go-MasterPassword is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// go-MasterPassword is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You can find a copy of the GNU General Public License in the
+// LICENSE file.  Alternatively, see <http://www.gnu.org/licenses/>.
+//==============================================================================
+
+package debug
+
+import (
+	"bytes"
+	"log"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func captureLogOutput(f func()) string {
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+	f()
+	log.SetOutput(os.Stderr)
+
+	return buf.String()
+}
+
+func Test_wantDebug(t *testing.T) {
+	d := NewDebug()
+	d.SetFilename("foo/bar.go")
+
+	assert.True(t, d.wantDebug("foo/bar.go"))
+	assert.True(t, d.wantDebug("a/b/c/foo/bar.go"))
+	assert.False(t, d.wantDebug("bar.go"))
+	assert.False(t, d.wantDebug("ar.go"))
+}
+
+func TestDbg(t *testing.T) {
+	d := NewDebug()
+	d.SetFilename("debug/debug_internal_test.go")
+
+	expect := "ZtesTingZ"
+	output := captureLogOutput(func() {
+		d.Dbg(expect)
+	})
+	assert.Contains(t, output, expect)
+}


### PR DESCRIPTION
closes #5 

This feature adds the ability to derive different passwords for a site based on the given password's purpose.
- auth | An authentication token such as a password
- ident | An identification token such as a username
- rec | A recovery token such as a security answer
